### PR TITLE
Fixes to adding filters to index

### DIFF
--- a/faiss/IndexFlat.h
+++ b/faiss/IndexFlat.h
@@ -85,8 +85,8 @@ struct IndexFlatL2 : IndexFlat {
 
 struct IndexFlatFusion : IndexFlat {
     explicit IndexFlatFusion(idx_t d) : IndexFlat(d, METRIC_FUSION) {}
-    explicit IndexFlatFusion(idx_t d, size_t filter_size)
-            : IndexFlat(d, METRIC_FUSION), filter_size(filter_size) {}
+    explicit IndexFlatFusion(idx_t d, size_t num_filters, size_t filter_dim)
+            : IndexFlat(d, METRIC_FUSION), filter_size(sizeof(float)*num_filters*filter_dim) {}
     IndexFlatFusion() {}
 
     size_t filter_size;

--- a/faiss/IndexFlat.h
+++ b/faiss/IndexFlat.h
@@ -102,7 +102,7 @@ struct IndexFlatFusion : IndexFlat {
         this->codes.resize((ntotal + n) * code_size);
         this->filters.resize((ntotal + n) * filter_size);
         sa_encode(n, x, codes.data() + (ntotal * code_size));
-        sa_encode(n, filters, this->filters.data() + (ntotal * filter_size));
+        memcpy(this->filters.data() + (ntotal * filter_size), filters, n * filter_size);
 
         ntotal += n;
     }

--- a/tutorial/cpp/6-Fusion.cpp
+++ b/tutorial/cpp/6-Fusion.cpp
@@ -57,7 +57,7 @@ int main() {
         xqf[fd * i] += i / 1000.;
     }
 
-    faiss::IndexFlatFusion index(d, fd); // call constructor
+    faiss::IndexFlatFusion index(d, num_filters, fd);  // call constructor
     printf("is_trained = %s\n", index.is_trained ? "true" : "false");
     index.add(nb, xb, xbf);              // add vectors to the index
     printf("ntotal = %zd\n", index.ntotal);


### PR DESCRIPTION
Fixes: 
- computing the size of the filters (missing number of filters per node)
- copying the filters to data member (sa_encode cannot be used with filters)